### PR TITLE
run semantic-release on push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Semantic Release
 on:
   push:
     branches:
-      - disabled_until_ready_for_continous_delivery
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
This PR makes semantic-release run on every push to `master`.