### PR TITLE
feat: add FindProject() method

### DIFF
--- a/project.go
+++ b/project.go
@@ -204,6 +204,21 @@ func (c *RollbarAPIClient) DeleteProject(projectID int) error {
 	return nil
 }
 
+// FindProject finds the Rollbar project with a given name.
+func (c *RollbarAPIClient) FindProject(name string) (*Project, error) {
+	projects, err := c.ListProjects()
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		if p.Name == name {
+			return &p, nil
+		}
+	}
+	return nil, ErrNotFound
+
+}
+
 // FindProjectTeamIDs finds IDs of all teams assigned to the project. Caution:
 // this is a potentially slow operation that makes multiple calls to the API.
 // https://github.com/rollbar/terraform-provider-rollbar/issues/104

--- a/project_test.go
+++ b/project_test.go
@@ -165,7 +165,7 @@ func (s *Suite) TestFindProject() {
 		}
 	actual, err := s.client.FindProject("foo")
 	s.Nil(err)
-	s.Equal(expected, actual)
+	s.Equal(&expected, actual)
 
 	_, err = s.client.FindProject("does_not_exist")
 	s.Equal(ErrNotFound, err)

--- a/project_test.go
+++ b/project_test.go
@@ -148,6 +148,34 @@ func (s *Suite) TestDeleteProject() {
 	})
 }
 
+// TestFindProject tests listing Rollbar projects.
+func (s *Suite) TestFindProject() {
+	u := s.client.BaseURL + pathProjectList
+
+	// Success
+	r := responderFromFixture("project/list.json", http.StatusOK)
+	httpmock.RegisterResponder("GET", u, r)
+	expected := Project {
+			ID:           411703,
+			Name:         "foo",
+			AccountID:    317418,
+			Status:       "enabled",
+			DateCreated:  1602085340,
+			DateModified: 1602085340,
+		}
+	actual, err := s.client.FindProject("foo")
+	s.Nil(err)
+	s.Equal(expected, actual)
+
+	_, err = s.client.FindProject("does_not_exist")
+	s.Equal(ErrNotFound, err)
+
+	s.checkServerErrors("GET", u, func() error {
+		_, err = s.client.FindProject("does_not_matter")
+		return err
+	})
+}
+
 // TestFindProjectTeamIDs tests finding the team IDs for a Rollbar project.
 func (s *Suite) TestFindProjectTeamIDs() {
 	var u string // URL


### PR DESCRIPTION
This PR adds a `FindProject()` method to find a Rollbar project by name.